### PR TITLE
Add missing 'l' in firstclass pattern

### DIFF
--- a/Dumper/src/NetVarManager/NetVarManager.cpp
+++ b/Dumper/src/NetVarManager/NetVarManager.cpp
@@ -111,7 +111,7 @@ namespace Dumper
 
         bool CNetVarManager::Load( void )
         {
-            auto firstclass = pProcess->FindPattern( "client.dll", "44 54 5F 54 45 57 6F 72 6C 64 44 65 63 61", 0, 0, 0 );
+            auto firstclass = pProcess->FindPattern( "client.dll", "44 54 5F 54 45 57 6F 72 6C 64 44 65 63 61 6C", 0, 0, 0 );
 
             std::stringstream ss;
             for( auto i = 0; i < 4; ++i ) {


### PR DESCRIPTION
The firstclass pattern uses 'DT_TEWorldDeca' but should be 'DT_TEWorldDecal' this doesn't really matter as the pattern is unique but to be correct this pull request adds the missing 'l'.
